### PR TITLE
Remove slashes from the label

### DIFF
--- a/golang/lint.go
+++ b/golang/lint.go
@@ -150,7 +150,7 @@ func GoInstall(args ...string) *Linter {
 	return &Linter{
 		Name:  "go",
 		Args:  append([]string{"install"}, args...),
-		Label: "Go/Install",
+		Label: "Go-Install",
 	}
 }
 
@@ -164,7 +164,7 @@ func GoVet(args ...string) *Linter {
 	return &Linter{
 		Name:  "go",
 		Args:  append([]string{"vet"}, args...),
-		Label: "Go/Vet",
+		Label: "Go-Vet",
 	}
 }
 
@@ -172,6 +172,6 @@ func GoTest(args ...string) *Linter {
 	return &Linter{
 		Name:  "go",
 		Args:  append([]string{"test"}, args...),
-		Label: "Go/Test",
+		Label: "Go-Test",
 	}
 }


### PR DESCRIPTION
On OS X, the slash causes problems when using the label as part of the temp dir.

```
lint.go:107: golang.linterSupport: 'Go/Install' in '...' failed: mkdir /var/folders/tn/09dglcts0b9gc5111hnf0_dm0000gn/T/margo.golang.Linter.Go/Install,465384526: no such file or directory
```

Consider this a bug report if you'd like to fix it some other way.